### PR TITLE
Integrate xterm.js for functional terminal emulator

### DIFF
--- a/frontend/src/components/Terminal.css
+++ b/frontend/src/components/Terminal.css
@@ -14,12 +14,14 @@
 
 .terminal {
   flex: 1;
-  padding: 0.5rem;
-  overflow: auto;
+  padding: 8px;
+  overflow: hidden;
 }
 
-.placeholder {
-  color: #666;
-  padding: 1rem;
-  font-family: monospace;
+.terminal .xterm {
+  height: 100%;
+}
+
+.terminal .xterm-viewport {
+  overflow-y: auto;
 }

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1,13 +1,70 @@
 import { useEffect, useRef } from 'react'
+import { Terminal as XTerm } from 'xterm'
+import { FitAddon } from 'xterm-addon-fit'
+import 'xterm/css/xterm.css'
 import './Terminal.css'
 
 function Terminal() {
   const terminalRef = useRef<HTMLDivElement>(null)
+  const xtermRef = useRef<XTerm | null>(null)
+  const fitAddonRef = useRef<FitAddon | null>(null)
 
   useEffect(() => {
-    // TODO: Initialize xterm.js here
-    // This is a placeholder for the actual terminal implementation
-    console.log('Terminal component mounted')
+    if (!terminalRef.current) return
+
+    const xterm = new XTerm({
+      theme: {
+        background: '#1e1e1e',
+        foreground: '#cccccc',
+        cursor: '#cccccc',
+        cursorAccent: '#1e1e1e',
+        selectionBackground: '#264f78',
+        black: '#000000',
+        red: '#cd3131',
+        green: '#0dbc79',
+        yellow: '#e5e510',
+        blue: '#2472c8',
+        magenta: '#bc3fbc',
+        cyan: '#11a8cd',
+        white: '#e5e5e5',
+        brightBlack: '#666666',
+        brightRed: '#f14c4c',
+        brightGreen: '#23d18b',
+        brightYellow: '#f5f543',
+        brightBlue: '#3b8eea',
+        brightMagenta: '#d670d6',
+        brightCyan: '#29b8db',
+        brightWhite: '#e5e5e5',
+      },
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      fontSize: 14,
+      cursorBlink: true,
+      convertEol: true,
+    })
+
+    const fitAddon = new FitAddon()
+    xterm.loadAddon(fitAddon)
+
+    xterm.open(terminalRef.current)
+    fitAddon.fit()
+
+    xterm.writeln('\x1b[1;34mTerminal is ready.\x1b[0m')
+    xterm.writeln('')
+    xterm.write('$ ')
+
+    xtermRef.current = xterm
+    fitAddonRef.current = fitAddon
+
+    const handleResize = () => {
+      fitAddon.fit()
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      xterm.dispose()
+    }
   }, [])
 
   return (
@@ -15,10 +72,7 @@ function Terminal() {
       <div className="terminal-header">
         <span>Terminal</span>
       </div>
-      <div ref={terminalRef} className="terminal" id="terminal">
-        {/* xterm.js will be attached here */}
-        <div className="placeholder">Terminal will be initialized here using xterm.js</div>
-      </div>
+      <div ref={terminalRef} className="terminal" id="terminal" />
     </div>
   )
 }


### PR DESCRIPTION
Fix: #1 

I've integrated xterm.js into the Terminal component. Here's what was implemented:

Imports: Added Terminal from xterm, FitAddon from xterm-addon-fit, and xterm CSS
Dark theme: Configured with VS Code-like dark colors
Fit addon: Makes terminal fill the container
Placeholder text: Shows "Terminal is ready." with a prompt
Cleanup: Properly disposes terminal on unmount
Resize handling: Fits terminal on window resize